### PR TITLE
Add message interaction, add bulk downloads

### DIFF
--- a/PromptInspector.py
+++ b/PromptInspector.py
@@ -1,19 +1,22 @@
 import io
 import os
 import toml
+import asyncio
 
-from discord import Client, Intents, Embed, ButtonStyle
+from discord import Client, Intents, Embed, ButtonStyle, Message, Attachment, File, Embed, Member, RawReactionActionEvent, ApplicationContext
+from discord.ext import commands
 from discord.ui import View, button
 from dotenv import load_dotenv
 from PIL import Image
+from collections import OrderedDict
 
 load_dotenv()
-MONITORED_CHANNEL_IDS = toml.load('config.toml')['MONITORED_CHANNEL_IDS']
+CONFIG = toml.load('config.toml')
+MONITORED_CHANNEL_IDS = CONFIG.get('MONITORED_CHANNEL_IDS', [])
+SCAN_LIMIT_BYTES = CONFIG.get('SCAN_LIMIT_BYTES', 10 * 1024**2)  # Default 10 MB
 
-intents = Intents.default()
-intents.message_content = True
-intents.members = True
-client = Client(intents=intents)
+intents = Intents.default() | Intents.message_content | Intents.members
+client = commands.Bot(intents=intents)
 
 
 def get_params_from_string(param_str):
@@ -40,12 +43,12 @@ def get_params_from_string(param_str):
     return output_dict
 
 
-def get_embed(embed_dict, context):
-    embed = Embed()
+def get_embed(embed_dict, context: Message):
+    embed = Embed(color=context.author.color)
     for key, value in embed_dict.items():
-        embed.add_field(name=key, value=value)
+        embed.add_field(name=key, value=value, inline='Prompt' not in key)
     pfp = context.author.avatar if context.author.avatar else context.author.default_avatar_url
-    embed.set_footer(text=f'Original post by {context.author}', icon_url=pfp)
+    embed.set_footer(text=f'Posted by {context.author}', icon_url=pfp)
     return embed
 
 
@@ -62,6 +65,8 @@ def read_info_from_image_stealth(image):
     reading_param_len = False
     reading_param = False
     read_end = False
+    if len(pixels[0, 0]) < 4:
+        return None
     for x in range(width):
         for y in range(height):
             _, _, _, a = pixels[x, y]
@@ -101,10 +106,8 @@ def read_info_from_image_stealth(image):
     if sig_confirmed and binary_data != '':
         # Convert binary string to UTF-8 encoded text
         decoded_data = bytearray(int(binary_data[i:i + 8], 2) for i in range(0, len(binary_data), 8)).decode('utf-8',errors='ignore')
-
-        geninfo = decoded_data
-
-    return geninfo
+        return decoded_data
+    return None
 
 
 @client.event
@@ -113,19 +116,19 @@ async def on_ready():
 
 
 @client.event
-async def on_message(message):
+async def on_message(message: Message):
     if message.channel.id in MONITORED_CHANNEL_IDS and message.attachments:
-        for attachment in message.attachments:
-            if attachment.content_type.startswith("image/"):
-                image_data = await attachment.read()
-                with Image.open(io.BytesIO(image_data)) as img:
-                    try:
-                        metadata = read_info_from_image_stealth(img)
-                        if 'Steps: ' in metadata:
-                          get_embed(get_params_from_string(metadata), message)
-                          await message.add_reaction('🔎')
-                    except:
-                        pass
+        attachments = [a for a in message.attachments if a.filename.lower().endswith(".png") and a.size < SCAN_LIMIT_BYTES]
+        for attachment in attachments:
+            image_data = await attachment.read()
+            with Image.open(io.BytesIO(image_data)) as img:
+                try:
+                    info = read_info_from_image_stealth(img)
+                    if info and 'Steps' in info:
+                        await message.add_reaction('🔎')
+                        return
+                except:
+                    pass
 
 
 class MyView(View):
@@ -144,28 +147,69 @@ class MyView(View):
           await interaction.followup.send(f"```yaml\n{self.metadata}```")
 
 
+async def read_attachment_metadata(i: int, attachment: Attachment, metadata: OrderedDict):
+    """Allows downloading in bulk"""
+    try:
+        image_data = await attachment.read()
+        with Image.open(io.BytesIO(image_data)) as img:
+            info = read_info_from_image_stealth(img)
+            if info and "Steps" in info:
+                metadata[i] = info
+    except Exception as error:
+        print(f"{type(error).__name__}: {error}")
+
+
 @client.event
-async def on_raw_reaction_add(ctx):
-    if ctx.emoji.name == '🔎':
-        channel = client.get_channel(ctx.channel_id)
-        message = await channel.fetch_message(ctx.message_id)
-        if not message:
-            return
-        if message.channel.id in MONITORED_CHANNEL_IDS and message.attachments and ctx.user_id != client.user.id:
-            for attachment in message.attachments:
-                if attachment.content_type.startswith("image/"):
-                    image_data = await attachment.read()
-                    with Image.open(io.BytesIO(image_data)) as img:
-                        try:
-                            metadata = read_info_from_image_stealth(img)
-                            embed = get_embed(get_params_from_string(metadata), message)
-                            embed.set_image(url=attachment.url)
-                            user_dm = await client.get_user(ctx.user_id).create_dm()
-                            custom_view = MyView()
-                            custom_view.metadata = metadata
-                            await user_dm.send(view=custom_view, embed=embed, mention_author=False)
-                        except:
-                            pass
+async def on_raw_reaction_add(ctx: RawReactionActionEvent):
+    """Send image metadata in reacted post to user DMs"""
+    if ctx.emoji.name != '🔎' or ctx.channel_id not in MONITORED_CHANNEL_IDS or ctx.author.bot:
+        return
+    channel = client.get_channel(ctx.channel_id)
+    message = await channel.fetch_message(ctx.message_id)
+    if not message:
+        return
+    attachments = [a for a in message.attachments if a.filename.lower().endswith(".png")]
+    if not attachments:
+        return
+    metadata = OrderedDict()
+    tasks = [read_attachment_metadata(i, attachment, metadata) for i, attachment in enumerate(attachments)]
+    await asyncio.gather(*tasks)
+    if not metadata:
+        return
+    user_dm = await client.get_user(ctx.user_id).create_dm()
+    for attachment, data in [(attachments[i], data) for i, data in metadata.items()]:
+        try:
+            embed = get_embed(get_params_from_string(data), message)
+            embed.set_image(url=attachment.url)
+            custom_view = MyView()
+            custom_view.metadata = metadata
+            await user_dm.send(view=custom_view, embed=embed, mention_author=False)
+        except:
+            pass
+
+
+@client.message_command(name="View Parameters")
+async def message_command(ctx: ApplicationContext, message: Message):
+    """Get raw list of parameters for every image in this post."""
+    attachments = [a for a in message.attachments if a.filename.lower().endswith(".png")]
+    if not attachments:
+        await ctx.respond("This post contains no matching images.", ephemeral=True)
+        return
+    await ctx.defer(ephemeral=True)
+    metadata = OrderedDict()
+    tasks = [read_attachment_metadata(i, attachment, metadata) for i, attachment in enumerate(attachments)]
+    await asyncio.gather(*tasks)
+    if not metadata:
+        await ctx.respond(f"This post contains no image generation data.\n{message.author.mention} needs to install [this extension](<https://github.com/ashen-sensored/sd_webui_stealth_pnginfo>).", ephemeral=True)
+        return
+    response = "\n\n".join(metadata.values())
+    if len(response) < 1980:
+        await ctx.respond(f"```yaml\n{response}```", ephemeral=True)
+    else:
+        with io.StringIO() as f:
+            f.write(response)
+            f.seek(0)
+            await ctx.respond(file=File(f, "parameters.yaml"), ephemeral=True)
 
 
 client.run(os.environ["BOT_TOKEN"])


### PR DESCRIPTION
This PR implements the following changes:
- Message Interaction: You can now right click a message and select "Apps -> View Parameters" to get the raw parameters for every image in a post. If the message exceeds the maximum length, it'll send a file instead (which can be previewed easily on desktop). The advantage of this method is that it displays it in the same channel you're in, and is invisible to other users.
- Bulk downloads: Instead of downloading images one at a time when requested, it'll perform as many parallel async tasks as necessary, greatly increasing speed.
- Adds a configurable filesize limit for images to download when scanning posts for 🔎
- Will only scan PNG files, as they are the only ones supported
- Switches from client to bot, which works the same but is cooler
- Adds some type hints in functions because autocomplete is nice
- Cleans up some code, such as using guard clauses instead of nested conditions
- Prompt and Negative Prompt are no longer inline which helps read them more easily