### PR TITLE
refactor(commands): View Parameters ➜ View Prompt

### DIFF
--- a/PromptInspector.py
+++ b/PromptInspector.py
@@ -270,7 +270,7 @@ async def on_raw_reaction_add(ctx: RawReactionActionEvent):
             pass
 
 
-@client.message_command(name="View Parameters")
+@client.message_command(name="View Prompt")
 async def message_command(ctx: ApplicationContext, message: Message):
     """Get raw list of parameters for every image in this post."""
     attachments = [a for a in message.attachments if a.filename.lower().endswith(".png")]


### PR DESCRIPTION
This change renames the "View Parameters" context menu command to "View Prompt" for clarity. The rationale behind this change is that while parameters may be more apt, most (especially the less technically-inclined) users are more familiar with the "Prompt" terminology, even if a prompt is only one portion of the puzzle for an image. 

This change is directed toward UX and Discoverability/a11y